### PR TITLE
docs(release): align deployment and handover docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # test_operator
 
-Backend implementation for issue `#3` lives in [`backend/`](/home/nhtony318/.worktrees/test_operator/tes-13/backend) and exposes the phase-2 auth, todo, and dashboard API described in [`docs/API_CONTRACT.md`](/home/nhtony318/.worktrees/test_operator/tes-13/docs/API_CONTRACT.md).
+Backend implementation for issue `#3` lives in [`backend/`](backend/) and exposes the phase-2 auth, todo, and dashboard API described in [`docs/API_CONTRACT.md`](docs/API_CONTRACT.md).
 
-Frontend implementation for issue `#10` lives in [`frontend/`](/home/nhtony318/.worktrees/test_operator/tes-8/frontend).
+Frontend implementation for issue `#4` lives in [`frontend/`](frontend/).
 
-Release-readiness artifacts for issue `#12` live in:
-- [`docs/DEPLOYMENT_CHECKLIST.md`](/home/nhtony318/.worktrees/test_operator/tes-10/docs/DEPLOYMENT_CHECKLIST.md)
-- [`docs/OPERATIONS.md`](/home/nhtony318/.worktrees/test_operator/tes-10/docs/OPERATIONS.md)
-- [`docs/HANDOVER.md`](/home/nhtony318/.worktrees/test_operator/tes-10/docs/HANDOVER.md)
+Release-readiness artifacts for issue `#6` live in:
+- [`docs/DEPLOYMENT_CHECKLIST.md`](docs/DEPLOYMENT_CHECKLIST.md)
+- [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
+- [`docs/HANDOVER.md`](docs/HANDOVER.md)
 
 ## Backend
 

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -1,10 +1,10 @@
 # Deployment Checklist
 
-This checklist is the phase 4 release baseline for issue `#12`.
+This checklist is the phase 4 release baseline for issue `#6`.
 
 ## 1. Build Readiness
 
-- Confirm issue dependency `#11` is closed.
+- Confirm issue dependency `#5` is closed.
 - Confirm the release branch is cut from `main`.
 - Confirm the local verification commands pass:
   - `cd backend && npm ci && npm run build && npm test`

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,6 +1,6 @@
 # Handover Notes
 
-## 1. Delivered In Issue `#12`
+## 1. Delivered In Issue `#6`
 
 - Deployment checklist in `docs/DEPLOYMENT_CHECKLIST.md`
 - Environment templates at `.env.example`, `backend/.env.example`, and `frontend/.env.example`


### PR DESCRIPTION
## Summary
- align release references in the deployment checklist and handover notes to issue #6 and dependency #5
- fix the README release artifact pointers so they resolve within this repository
- keep the existing env template and observability baseline unchanged because they are already present in the current codebase

## Verification
- cd backend && npm ci && npm run build && npm test
- cd frontend && npm ci && npm run lint && npm run test && npm run build

## Assumptions and tradeoffs
- limited this PR to release-readiness documentation hygiene for issue #6
- did not refactor non-release issue references outside the touched release-facing docs

Closes #6